### PR TITLE
FIX: Add transition delay to avoid flickering effect

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -34,6 +34,7 @@
 
         .custom-header-dropdown {
           transform: scale(1);
+          transition-delay: 0s;
         }
 
         .custom-header-link-caret svg {
@@ -74,7 +75,6 @@
       &:hover {
         color: $dropdown_item_hover_color;
         background: $dropdown_item_hover_background_color;
-        transition-delay: 0s;
       }
     }
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -54,6 +54,7 @@
     list-style: none;
     transform: scale(0);
     transition: transform 0.2s ease;
+    transition-delay: 0.3s;
 
     &-link {
       color: $dropdown_item_color;
@@ -73,6 +74,7 @@
       &:hover {
         color: $dropdown_item_hover_color;
         background: $dropdown_item_hover_background_color;
+        transition-delay: 0s;
       }
     }
   }


### PR DESCRIPTION
The dropdown currently is a bit flaky; moving your cursor to slow or too fast makes it close. Adding a minor delay solves the issue.