### PR TITLE
FEATURE: Close mobile nav on link click

### DIFF
--- a/javascripts/discourse/widgets/custom-header-dropdown.js.es6
+++ b/javascripts/discourse/widgets/custom-header-dropdown.js.es6
@@ -24,6 +24,9 @@ createWidget('custom-header-dropdown', {
   },
 
   click() {
+    if (this.site.mobileView) {
+      this.sendWidgetAction("showHeaderLinks"); // in mobile view, close menu on click
+    }
     DiscourseURL.routeTo(this.attrs.url);
   },
 });

--- a/javascripts/discourse/widgets/custom-header-link.js.es6
+++ b/javascripts/discourse/widgets/custom-header-link.js.es6
@@ -109,6 +109,9 @@ createWidget("custom-header-link", {
   },
 
   click() {
+    if (this.site.mobileView) {
+      this.sendWidgetAction("showHeaderLinks"); // in mobile view, close menu on click
+    }
     DiscourseURL.routeTo(this.attrs.url);
   },
 });

--- a/javascripts/discourse/widgets/custom-header-links.js.es6
+++ b/javascripts/discourse/widgets/custom-header-links.js.es6
@@ -56,6 +56,7 @@ createWidget('custom-header-links', {
             {{attach
               widget="custom-header-link"
               attrs=item
+              showHeaderLinks="showHeaderLinks"
             }}
           {{/each}}
       </ul>


### PR DESCRIPTION
On mobile, when a link is clicked, since the mobile nav stays open after the click it can be difficult to tell if the page changed, especially on larger navigations.

**This PR:** Allows for the mobile navigation to be closed after clicking on a link in the mobile nav.

https://user-images.githubusercontent.com/30090424/195946416-d6e1f34b-4864-469c-8e06-5c73e69c98e3.mov

