### PR TITLE
UX: Improve mobile nav experience

### DIFF
--- a/javascripts/discourse/widgets/custom-header-links.js.es6
+++ b/javascripts/discourse/widgets/custom-header-links.js.es6
@@ -44,6 +44,9 @@ createWidget('custom-header-links', {
   },
 
   clickOutside() {
+    if (this.site.desktopView) {
+      return;
+    }
     this.sendWidgetAction("toggleHeaderLinks");
   },
 

--- a/javascripts/discourse/widgets/custom-header-links.js.es6
+++ b/javascripts/discourse/widgets/custom-header-links.js.es6
@@ -43,7 +43,7 @@ createWidget('custom-header-links', {
     }
   },
 
-  clickOutside(e) {
+  clickOutside() {
     this.sendWidgetAction("toggleHeaderLinks");
   },
 

--- a/javascripts/discourse/widgets/custom-header-links.js.es6
+++ b/javascripts/discourse/widgets/custom-header-links.js.es6
@@ -47,7 +47,10 @@ createWidget('custom-header-links', {
     if (this.site.desktopView) {
       return;
     }
-    this.sendWidgetAction("toggleHeaderLinks");
+
+    if (this.state.showLinks) {
+      this.sendWidgetAction("toggleHeaderLinks");
+    }
   },
 
   template: hbs`

--- a/javascripts/discourse/widgets/custom-header-links.js.es6
+++ b/javascripts/discourse/widgets/custom-header-links.js.es6
@@ -34,8 +34,17 @@ createWidget('custom-header-links', {
     };
   },
 
-  showHeaderLinks() {
+  toggleHeaderLinks() {
     this.state.showLinks = !this.state.showLinks;
+    if (this.state.showLinks) {
+      document.body.classList.add("dropdown-header-open");
+    } else {
+      document.body.classList.remove("dropdown-header-open");
+    }
+  },
+
+  clickOutside(e) {
+    this.sendWidgetAction("toggleHeaderLinks");
   },
 
   template: hbs`
@@ -44,7 +53,7 @@ createWidget('custom-header-links', {
         {{attach
             widget="button"
             attrs=(hash
-              action="showHeaderLinks"
+              action="toggleHeaderLinks"
               icon="caret-square-down"
             )
         }}

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,4 +1,4 @@
-@import 'mixins';
+@import "mixins";
 
 .mobile-view {
   .top-level-links {
@@ -32,5 +32,11 @@
     .custom-header-link-desc {
       display: none;
     }
+  }
+
+  .dropdown-header-open {
+    overflow-y: hidden;
+    height: 100vh;
+    position: fixed;
   }
 }


### PR DESCRIPTION
### This PR improves the mobile navigation experience by:
- Allowing clicking outside the dropdown menu to close the menu
- Preventing the background from scrolling when a dropdown menu is open

This PR also renames the `showHeaderLinks()` action to a more suitable name: `toggleHeaderLinks()` as the action can be called to either hide or show the header links.