### PR TITLE
[untested] build `.custom-header-link-title` with an `<a>` tag if URL present

### DIFF
--- a/javascripts/discourse/widgets/custom-header-link.js.es6
+++ b/javascripts/discourse/widgets/custom-header-link.js.es6
@@ -11,7 +11,9 @@ createWidget("custom-header-link", {
 
   html(attrs) {
     const iconHTML = buildIconHTML(attrs.icon);
-    const titleHTML = h("span.custom-header-link-title", attrs.title);
+    const titleHTML = attrs.url
+      ? h(   "a.custom-header-link-title", attrs.title, {href: attrs.url})
+      : h("span.custom-header-link-title", attrs.title);
     const permissions = this.handleLinkPermissions(attrs);
     const allDropdownItems = settings.dropdown_links
       ? JSON.parse(settings.dropdown_links)


### PR DESCRIPTION
Ultra-basic attempt to address #3 — if there is a URL defined for the entry, build the HTML using an `<a>` tag, otherwise use a `<span>` as before.

(This would address the first and second point listed in the Issue, but not the third.)