### PR TITLE
DEV: update deprecated icon name from caret-square-down to square-caret-down

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,1 +1,2 @@
+< 3.4.0.beta2-dev: 7151c2cd4e150c70ad6b6e320369bec25c2df402
 < 3.3.0.beta1-dev: f3561ce7fd9dded965fb8e9a99229539c7af3aa1

--- a/about.json
+++ b/about.json
@@ -7,7 +7,7 @@
   "assets": {},
   "modifiers": {
     "svg_icons": [
-      "caret-square-down"
+      "square-caret-down"
     ]
   }
 }

--- a/javascripts/discourse/components/custom-header-links.gjs
+++ b/javascripts/discourse/components/custom-header-links.gjs
@@ -40,7 +40,7 @@ export default class CustomHeaderLinks extends Component {
       {{#if this.site.mobileView}}
         <span class="btn-custom-header-dropdown-mobile">
           <DButton
-            @icon="caret-square-down"
+            @icon="square-caret-down"
             @title={{i18n "custom_header.discord"}}
             @action={{this.toggleHeaderLinks}}
           />


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.