### PR TITLE
fix: remove shadow band and scrollbar track in mobile flyout

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -11,8 +11,15 @@
     flex-flow: row wrap;
     align-items: flex-start;
     justify-content: flex-start;
-    overflow: scroll;
+    // overflow: scroll forces both x and y scrollbar tracks to always render,
+    // adding ~15px of blank space at the bottom even when content fits.
+    overflow-y: auto;
+    overflow-x: hidden;
     max-height: 90vh;
+    // @include dropdown adds box-shadow for a compact floating box, but the
+    // mobile flyout is position: fixed; width: 100%, so the shadow spans the
+    // full viewport width and appears as a dark band below the last link.
+    box-shadow: none;
 
     li {
       width: 100%;


### PR DESCRIPTION
## Summary

Two visual artifacts appear in the mobile flyout panel (`.mobile-view .top-level-links`), both most noticeable in dark mode:

- **Trailing shadow band** — `@include dropdown` includes `box-shadow: 0 12px 12px rgb(0 0 0 / 15%)`. On the desktop dropdown this looks natural (small floating box, max-width 280px). But the mobile flyout is `position: fixed; width: 100%`, so the shadow spans the full viewport width and appears as a dark semi-transparent bar below the last link. Fix: add `box-shadow: none` to override the mixin in this context.

- **Horizontal scrollbar track** — `overflow: scroll` forces both x and y scrollbar tracks to always render. The horizontal track (~15px tall) appears at the bottom of the flyout and is visually indistinguishable from extra padding, even when there is nothing to scroll horizontally. Fix: `overflow-y: auto; overflow-x: hidden`.

## Changes

Only `mobile/mobile.scss` is modified — one property changed, one property added, with comments explaining the root cause of each.

## Test plan

- [ ] Open site on mobile or narrow desktop (< 712px)
- [ ] Toggle the flyout open
- [ ] Confirm no dark band appears below the last link
- [ ] Confirm no horizontal scrollbar track appears at the bottom of the panel
- [ ] Test in both light mode and dark mode (band is most visible in dark mode)

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>